### PR TITLE
Fixed unlimited scrolling render

### DIFF
--- a/src/pages/search/search.html
+++ b/src/pages/search/search.html
@@ -27,10 +27,12 @@
   </ng-template>
 
   <ng-template #elseBlock>
-    <ion-item text-wrap *ngFor="let repo of searchResults | keyvalue: keyDescValueOrder">
-        <p>{{repo.key}}</p>
-        <p>{{repo.value.name}}</p>
-    </ion-item>
+    <ion-list>
+        <ion-item text-wrap *ngFor="let repo of searchResults | keyvalue: keyDescValueOrder">
+            <p>{{repo.key}}</p>
+            <p>{{repo.value.name}}</p>
+        </ion-item>
+    </ion-list>
   </ng-template>
 
   <ion-infinite-scroll (ionInfinite)="renderMoreResults(searchQuery, $event)">


### PR DESCRIPTION
When rendering the next page, the view would render
the end of the page's results, instead of the beginning

ie: when loading results 30-59, the view would be at
result 59 and trigger the next page rendering