### PR TITLE
Fix bug to hide infinite scrolling if no link header exists

### DIFF
--- a/src/pages/search/search.ts
+++ b/src/pages/search/search.ts
@@ -47,6 +47,8 @@ export class SearchPage {
         .subscribe(res => {
           if (res.headers.get('Link') != null) {
             this.linkHeader = res.headers.get('Link');
+          } else {
+            this.hideInfiniteScroll = true;
           }
           this.resultsCount = res.body.total_count;
           for (var repo of res.body.items) {


### PR DESCRIPTION
If no link header exists, then ion-item message indicating end of
search results does not appear.

This commit fixes that.