### PR TITLE
Fixed advanced search page bugs

### DIFF
--- a/src/pages/advanced-search/advanced-search.html
+++ b/src/pages/advanced-search/advanced-search.html
@@ -49,7 +49,6 @@
   <ion-item>
     <ion-label stacked>Written in this language</ion-label>
     <ion-select [(ngModel)]="inputArray[2]" placeholder='Language (default: Any)' [selectedText]="inputArray[2]">
-      <ion-option value="">Any</ion-option>
       <ion-option *ngFor="let language of languageArray" [value]="language">{{language}}</ion-option>
     </ion-select>
   </ion-item>

--- a/src/pages/advanced-search/advanced-search.ts
+++ b/src/pages/advanced-search/advanced-search.ts
@@ -12,11 +12,11 @@ export class AdvancedSearchPage {
   searchQuery: string = '';
 
   queryArray: string[] = [
-    'org:',
-    'stars:',
-    'language:',
-    'good-first-issues:',
-    'help-wanted-issues:'
+    'org',
+    'stars',
+    'language',
+    'good-first-issues',
+    'help-wanted-issues'
   ]
 
   inputArray: string[] = [
@@ -28,6 +28,7 @@ export class AdvancedSearchPage {
   ]
 
   languageArray: string[] = [
+    'Any',
     'C',
     'C#',
     'C++',
@@ -54,12 +55,17 @@ export class AdvancedSearchPage {
   ]
 
   constructor(public navCtrl: NavController, public navParams: NavParams) {
-    this.searchQuery = window.localStorage.getItem('searchQuery');
-    this.inputArray[0] = window.localStorage.getItem('orgInput');
-    this.inputArray[1] = window.localStorage.getItem('starsInput');
-    this.inputArray[2] = window.localStorage.getItem('languageInput');
-    this.inputArray[3] = window.localStorage.getItem('goodFirstIssuesInput');
-    this.inputArray[4] = window.localStorage.getItem('helpWantedLabelsInput');
+    let searchQuery = window.localStorage.getItem('searchQuery');
+    if (searchQuery != null) {
+      this.searchQuery = searchQuery;
+    }
+
+    for (var i = 0; i < 5; i++) {
+      let queryVariable = window.localStorage.getItem(this.queryArray[i]);
+      if (queryVariable != null) {
+        this.inputArray[i] = queryVariable;
+      }
+    }
   }
 
   forwardSearchQuery() {
@@ -73,20 +79,24 @@ export class AdvancedSearchPage {
   formSearchQuery() {
     this.fullQuery = this.searchQuery;
     for (var i = 0; i < 5; i++) {
-      if (this.inputArray[i].length > 0) {
-        this.queryArray[i] += this.inputArray[i];
-        this.fullQuery += ` ${this.queryArray[i]}`;
+      if (this.inputArray[i].length > 0 && this.inputArray[i] != 'Any') {
+        this.fullQuery += ` ${this.queryArray[i]}:${this.inputArray[i]}`;
       }
     }
   }
 
   saveInputsToLocalStorage() {
-    window.localStorage.setItem('searchQuery', this.searchQuery);
-    window.localStorage.setItem('orgInput', this.inputArray[0]);
-    window.localStorage.setItem('starsInput', this.inputArray[1]);
-    window.localStorage.setItem('languageInput', this.inputArray[2]);
-    window.localStorage.setItem('goodFirstIssuesInput', this.inputArray[3]);
-    window.localStorage.setItem('helpWantedLabelsInput', this.inputArray[4]);
+    let searchQuery = this.searchQuery;
+    if (searchQuery != null) {
+      window.localStorage.setItem('searchQuery', searchQuery);
+    }
+
+    for (var i = 0; i < 5; i++) {
+      let input = this.inputArray[i];
+      if (input != null) {
+        window.localStorage.setItem(this.queryArray[i], input);
+      }
+    }
   }
 
 }


### PR DESCRIPTION
- Fixed a runtime error: `Cannot read property 'length' of null`,
where this occurs when an advanced search is made with the advanced
fields being empty
- This error would occur because the advanced search fields are
stored in local storage so that they persist, and due to this, when
no values are set in the page, the values are saved as `null` in
local storage, then when the `formSearchQuery()` function tries to
determine the length of `null`, the error is thrown
- The solution is to initialize the values to an empty string
- Also reworked `saveInputsToLocalStorage()` logic so the empty
strings are saved to local storage instead of `null` values
- Fixed a bug where the `Any` language value does not persist, by
moving the value from the html to the component code